### PR TITLE
Removed Shared I2C Bus Feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adafruit-lcd-backpack"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Unofficial driver for the Adafruit I2C LCD backpack"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,9 @@ bench = false
 
 [dependencies]
 embedded-hal = "0.2"
-# The shared_i2c feature of mcp230xx is not yet released, so we need to use a git dependency.
-# This PR adds the feature: https://github.com/quartiq/mcp230xx/pull/6
-mcp230xx = { git = "https://github.com/michaelkamprath/mcp230xx.git", branch = "rc_i2c", version = "0.2" }
+mcp230xx = "1.0.0"
 # The defmt feature is optional, enabling formatters for defmt logging.
 defmt = { version = "0.3", optional = true }
 
 [features]
-shared_i2c = ["mcp230xx/shared_i2c"]
 defmt = ["dep:defmt"]

--- a/README.md
+++ b/README.md
@@ -8,15 +8,9 @@ _NOTE: This library is not made by Adafruit, and is not supported by them. The u
 is for compatibility identification purposes only._
 
 ## Overview
-This crate provides a driver for the Adafruit I2C LCD backpack with MCP23008 GPIO expander. It is designed to be used with the 
+This crate provides a driver for the Adafruit I2C LCD backpack with MCP23008 GPIO expander. It is designed to be used with the
 [embedded-hal](https://docs.rs/embedded-hal/latest/embedded_hal/index.html) traits for embeded systems. It supports standard
 HD44780 based LCD displays.
-
-## Features
-The feature `shared_i2c` can be enabled to allow the I2C bus to be shared with other devices. This is useful for devices like the
-Raspberry Pi Pico that have a single I2C bus. When this feature is enabled, the I2C bus is wrapped in an `Rc<RefCell<_>>` and
-passed to the LCD backpack. When this feature is not enabled, the I2C bus is passed directly to the LCD backpack and consumed during
-initialization.
 
 ## Usage
 To create a new LCD backpack, use the `new` method. This will return a new LCD backpack object. Pass it the type of LCD display you
@@ -60,44 +54,6 @@ allows you to chain the methods together. For example:
 // clear the display and home the cursor before writing a string
 if let Err(_e) = write!(lcd.clear()?.home()?, "Hello, world!") {
  panic!("Error writing to LCD");
-}
-```
-### Shared I2C Bus
-If you are using a platform with a single I2C bus, you can enable the `shared_i2c` feature to allow the I2C bus to be shared with
-other devices and sensors. That is, the I2C bus is wrapped in an `Rc<RefCell<_>>` and passed to the LCD backpack, meaning the
-I2C bus object is not moved into the LCD backpack during initialization. Doing this requires that your project have an allocator
-defined, such as [`embedded_alloc`](https://github.com/rust-embedded/embedded-alloc), allowing the use of the alloc::rc::Rc and 
-core::cell::RefCell types.
-
-When using the `shared_i2c` feature, the initial setup now looks like this (ignoring the creation of the allocator):
-
-```rust
-// The embedded-hal traits are used to define the I2C bus and delay objects
-use embedded_hal::{
-   blocking::delay::{DelayMs, DelayUs},
-   blocking::i2c::{Write, WriteRead},
-};
-
-// The alloc crate is used to define the Rc and RefCell types
-use alloc::rc::Rc;
-use core::cell::RefCell;
-
-use lcd_backpack::{LcdBackpack, LcdDisplayType};
-
-// create the I2C bus per your platform
-let i2c = ...;
-let i2c = Rc::new(RefCell::new(i2c));
-
-// create the delay object per your platform
-let delay = ...;
-let delay = Rc::new(RefCell::new(delay));
-
-// create the LCD backpack
-let mut lcd = LcdBackpack::new(LcdDisplayType::Lcd16x2, &i2c, &delay);
-
-// initialize the LCD
-if let Err(_e) = lcd.init() {
-  panic!("Error initializing LCD");
 }
 ```
 


### PR DESCRIPTION
Removed the shared I2C bus feature. Instead, clients should use something like [`shared-bus`](https://docs.rs/shared-bus/).